### PR TITLE
Add support for overriding the resolved path for a given Module or Dist.

### DIFF
--- a/lib/File/ShareDir.pm
+++ b/lib/File/ShareDir.pm
@@ -552,6 +552,49 @@ sub _FILE {
 
 =pod
 
+=head1 EXTENDING
+
+=head2 Overriding Directory Resolution
+
+C<File::ShareDir> has two convenience hashes for people who have advanced usage
+requirements of C<File::ShareDir> such as using uninstalled C<share>
+directories during development.
+
+  #
+  # Dist-Name => /absolute/path/for/DistName/share/dir
+  #
+  %File::ShareDir::DIST_SHARE
+
+  #
+  # Module::Name => /absolute/path/for/Module/Name/share/dir
+  #
+  %File::ShareDir::MODULE_SHARE
+
+Setting these values any time before the corresponding calls
+
+  dist_dir('Dist-Name')
+  dist_file('Dist-Name','some/file');
+
+  module_dir('Module::Name');
+  module_file('Module::Name','some/file');
+
+Will override the base directory for resolving those calls.
+
+An example of where this would be useful is in a test for a module that depends
+on files installed into a share dir, to enable the tests to use the development
+copy without needing to install them first.
+
+  use File::ShareDir;
+  use Cwd qw( getcwd );
+  use File::Spec::Functions qw( rel2abs catdir );
+
+  $File::ShareDir::MODULE_SHARE{'Foo::Module'} = rel2abs(catfile(getcwd,'share'));
+
+  use Foo::Module;
+
+  # interal calls in Foo::Module to module_file('Foo::Module','bar') now resolves to
+  # the source trees share/ directory instead of something in @INC
+
 =head1 SUPPORT
 
 Bugs should always be submitted via the CPAN bug tracker

--- a/lib/File/ShareDir.pm
+++ b/lib/File/ShareDir.pm
@@ -115,7 +115,7 @@ use Exporter         ();
 use File::Spec       ();
 use Class::Inspector ();
 
-use vars qw{ $VERSION @ISA @EXPORT_OK %EXPORT_TAGS };
+use vars qw{ $VERSION @ISA @EXPORT_OK %EXPORT_TAGS %DIST_SHARE %MODULE_SHARE };
 BEGIN {
 	$VERSION     = '1.103';
 	@ISA         = qw{ Exporter };
@@ -175,6 +175,8 @@ sub dist_dir {
 
 sub _dist_dir_new {
 	my $dist = shift;
+
+	return $DIST_SHARE{$dist} if exists $DIST_SHARE{$dist};
 
 	# Create the subpath
 	my $path = File::Spec->catdir(
@@ -238,6 +240,9 @@ located or is not readable.
 
 sub module_dir {
 	my $module = _MODULE(shift);
+
+	return $MODULE_SHARE{$module} if exists $MODULE_SHARE{$module};
+
 	my $dir;
 
 	# Try the new version

--- a/t/03_extensions.t
+++ b/t/03_extensions.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+# ABSTRACT: Test for overriding paths
+
+use File::ShareDir qw( dist_dir dist_file module_dir module_file );
+use Cwd qw( getcwd );
+
+my $FAKE_DIST   = 'Fake-Sample-Dist';
+my $FAKE_MODULE = 'Fake::Sample::Module';
+
+{
+
+    package Fake::Sample::Module;
+    $INC{'Fake/Sample/Module.pm'} = 1;
+}
+
+$File::ShareDir::DIST_SHARE{$FAKE_DIST}     = getcwd;
+$File::ShareDir::MODULE_SHARE{$FAKE_MODULE} = getcwd;
+
+is( dist_dir($FAKE_DIST), getcwd,
+    "Fake distribution resolves to forced value" );
+ok(
+    -f dist_file( $FAKE_DIST, 't/03_extensions.t' ),
+    "Fake distribution resolves to forced value with a file"
+);
+
+is( module_dir($FAKE_MODULE), getcwd, "Fake module resolves to forced value" );
+ok(
+    -f module_file( $FAKE_MODULE, 't/03_extensions.t' ),
+    "Fake module resolves to forced value with a file"
+);
+
+done_testing;
+


### PR DESCRIPTION
As per request [rt#95721 [Feature request] Add official way to override share resoluion](https://rt.cpan.org/Ticket/Display.html?id=95721)

This is the simplest approach I could think of that might be useful enough to be extensible.

The logic for `Dist` must go in `_dist_dir_new()` because it is directly called `_dist_file_new()` but `_dist_dir()` is not called anywhere in `_dist_file()`
