### PR TITLE
File::ShareDir::Install fixes and restoration of Perl 5.6 support

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,7 +26,7 @@ my %TEST_DEPS = (
 );
 
 WriteMakefile1(
-    MIN_PERL_VERSION => '5.008001',
+    MIN_PERL_VERSION => '5.006000',   # inc/File-ShareDir-Install minimum
     META_ADD         => {
         'meta-spec' => { version => 2 },
         resources   => {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,14 +3,8 @@ use warnings;
 
 use ExtUtils::MakeMaker;
 
-BEGIN
-{
-    eval "use File::ShareDir::Install;";
-    $@ and eval "use lib qw,inc/File-ShareDir-Install,; use File::ShareDir::Install;";
-    $@ and die $@;
-}
-
-use File::ShareDir::Install 0.03;
+use lib 'inc/File-ShareDir-Install';
+use File::ShareDir::Install;
 
 install_share 'share';
 
@@ -25,7 +19,6 @@ my %RUN_DEPS = (
 );
 my %BUILD_DEPS = (
     'ExtUtils::MakeMaker'     => 0,
-    'File::ShareDir::Install' => '0.03'
 );
 
 my %TEST_DEPS = (
@@ -60,7 +53,6 @@ WriteMakefile1(
             },
             configure => {
                 requires   => {%BUILD_DEPS},
-                recommends => { 'File::ShareDir::Install' => '0.08' }
             },
             build   => { requires => {%BUILD_DEPS} },
             test    => { requires => {%TEST_DEPS} },

--- a/inc/File-ShareDir-Install/File/ShareDir/Install.pm
+++ b/inc/File-ShareDir-Install/File/ShareDir/Install.pm
@@ -1,6 +1,6 @@
 package File::ShareDir::Install;
 
-use 5.008;
+use 5.006; # minimum for "our"
 use strict;
 use warnings;
 

--- a/inc/File-ShareDir-Install/File/ShareDir/Install.pm
+++ b/inc/File-ShareDir-Install/File/ShareDir/Install.pm
@@ -9,7 +9,7 @@ use Carp;
 use File::Spec;
 use IO::Dir;
 
-our $VERSION = '0.08';
+our $VERSION = '0.10';
 
 our @DIRS;
 our %ALREADY;
@@ -134,7 +134,6 @@ sub __postamble_share_dir
 
     my $dir = $def->{dir};
 
-    $DB::single = 1;
     my( $idir );
 
     if( $def->{type} eq 'delete-dist' ) {
@@ -216,7 +215,7 @@ sub _scan_share_dir
             else {
                 next if $entry =~ /^\./;
             }
-            _scan_share_dir( $files, File::Spec->catdir( $idir, $entry ), $full );
+            _scan_share_dir( $files, File::Spec->catdir( $idir, $entry ), $full, $def );
         }
     }
 }


### PR DESCRIPTION
I discovered earlier this morning that File::ShareDir 1.101 degraded the perl support level from 5.005 back to 5.008.

Attached Patch sequence attempts to:
- Restore Perl support back to 5.006
- Tidy up Makefile.PL to avoid the need to depend-on _and_ bundle File::ShareDir::Install
- Import some very minor tweaks to File::ShareDir::Install from its 0.10 release. ( With patches for 5.006 support which will be submitted upstream as soon as ether gets a git copy of the project working )

Toolchain don't see much value in depending on File::ShareDir::Install if you're already bundling it. Seems like you've already paid the price of complexity by bundling it, may as well benefit from bundling it =)
