### PR TITLE
Fixed author test.

### DIFF
--- a/lib/File/ShareDir.pm
+++ b/lib/File/ShareDir.pm
@@ -435,6 +435,13 @@ else
 {
     ## no critic (ErrorHandling::RequireCheckingReturnValueOfEval)
     eval <<'END_OF_BORROWED_CODE';
+
+=head2 firstres
+
+Find the full dir within @INC.
+
+=cut
+
 sub firstres (&@)
 {
     my $test = shift;

--- a/xt/perltidy.t
+++ b/xt/perltidy.t
@@ -4,7 +4,9 @@ use strict;
 use warnings;
 
 use Test::More;
-use Test::PerlTidy;
+
+eval "use Test::PerlTidy";
+plan skip_all => "Test::PerlTidy required" if $@;
 
 run_tests(
     perltidyrc => '.perltidyrc',

--- a/xt/spelling.t
+++ b/xt/spelling.t
@@ -10,3 +10,5 @@ __END__
 AnnoCPAN
 Jens
 Rehsack
+dir
+firstres


### PR DESCRIPTION
Hi @rehsack 

Please review the PR.
It address the following errors:

    xt/perltidy.t ...... Can't locate Test/PerlTidy.pm in @INC (you may need to install the Test::PerlTidy module) 
    (@INC contains: /home/manwar/File-ShareDir/blib/lib /home/manwar/File-ShareDir/blib/arch /etc/pe
    l /usr/local/lib/perl/5.18.2 /usr/local/share/perl/5.18.2 /usr/lib/perl5 /usr/share/perl5 /usr/lib/perl/5.18 
    /usr/share/perl/5.18 /usr/local/lib/site_perl .) at xt/perltidy.t line 7.
    BEGIN failed--compilation aborted at xt/perltidy.t line 7.
    xt/perltidy.t ...... Dubious, test returned 2 (wstat 512, 0x200)
    No subtests run 
    xt/pod-cm.t ........ ok   
    xt/pod-coverage.t .. 1/1 
    #   Failed test 'Pod coverage on File::ShareDir'
    #   at /usr/local/share/perl/5.18.2/Test/Pod/Coverage.pm line 133.
    # Coverage for File::ShareDir is 83.3%, with 1 naked subroutine:
    #       firstres
    # Looks like you failed 1 test of 1.
    xt/pod-coverage.t .. Dubious, test returned 1 (wstat 256, 0x100)
    Failed 1/1 subtests 

Many Thanks.
Best Regards,
Mohammad S Anwar