### PR TITLE
Fix warnings

### DIFF
--- a/t/00_prereqs.t
+++ b/t/00_prereqs.t
@@ -49,9 +49,18 @@ foreach my $phase (qw/configure build runtime test/, (-d "xt" ? "develop" : ()))
             if (eval { require_ok($module) unless $module eq 'perl'; 1 })
             {
                 my $version = $module eq 'perl' ? $] : $module->VERSION;
-                $len{have} < length($version) and $len{have} = length($version);
-                my $ok = ok($reqs->accepts_module($module, $version), "$module matches required $version");
-                my $status = $ok ? "ok" : "not ok";
+                my $status;
+                if (defined $version)
+                {
+                    $len{have} < length($version) and $len{have} = length($version);
+                    my $ok = ok($reqs->accepts_module($module, $version), "$module matches required $version");
+                    $status = $ok ? "ok" : "not ok";
+                }
+                else
+                {
+                    $status  = "not ok";
+                    $version = "n/a";
+                }
                 $report{$phase}{$severity}{$module} = {
                     want   => $want,
                     have   => $version,

--- a/t/06_old.t
+++ b/t/06_old.t
@@ -25,22 +25,26 @@ is(File::ShareDir::_DIST('ShareDir-TestClass'),    'ShareDir-TestClass',  '_DIST
 
 remove_tree($testautolib);
 make_path($testsharedirold, {mode => 0700});
-open(my $fh, ">", File::Spec->catfile($testsharedirold, qw(sample.txt)));
-close($fh);
+SKIP:
+{
+    open(my $fh, ">", File::Spec->catfile($testsharedirold, qw(sample.txt)))
+      or skip "Can't write to [$testsharedirold]: $!", 9;
+    close($fh);
 
-my $module_dir = module_dir('ShareDir::TestClass');
-ok($module_dir,    'Can find our own module dir');
-ok(-d $module_dir, '... and is a dir');
-ok(-r $module_dir, '... and have read permissions');
+    my $module_dir = module_dir('ShareDir::TestClass');
+    ok($module_dir,    'Can find our own module dir');
+    ok(-d $module_dir, '... and is a dir');
+    ok(-r $module_dir, '... and have read permissions');
 
-my $dist_dir = dist_dir('ShareDir-TestClass');
-ok($dist_dir,    'Can find our own dist dir');
-ok(-d $dist_dir, '... and is a dir');
-ok(-r $dist_dir, '... and have read permissions');
+    my $dist_dir = dist_dir('ShareDir-TestClass');
+    ok($dist_dir,    'Can find our own dist dir');
+    ok(-d $dist_dir, '... and is a dir');
+    ok(-r $dist_dir, '... and have read permissions');
 
-my $dist_file = dist_file('ShareDir-TestClass', 'sample.txt');
-ok($dist_file,    'Can find our sample module file');
-ok(-f $dist_file, '... and is a file');
-ok(-r $dist_file, '... and have read permissions');
+    my $dist_file = dist_file('ShareDir-TestClass', 'sample.txt');
+    ok($dist_file,    'Can find our sample module file');
+    ok(-f $dist_file, '... and is a file');
+    ok(-r $dist_file, '... and have read permissions');
+}
 
 done_testing;


### PR DESCRIPTION
Hi @rehsack 

Please review the PR.
Address the FAIL report:
https://www.cpantesters.org/cpan/report/42ebf7c0-77d0-11e8-b18d-822462266ff8


      1) Remove warnings 'Use of unitialized values..'
   
            Use of uninitialized value in numeric lt (<) at t/00_prereqs.t line 52.
            Use of uninitialized value $version in concatenation (.) or string at t/00_prereqs.t line 53.
            Use of uninitialized value $have in sprintf at t/00_prereqs.t line 89.

      2) Handle test failure better.

             Directory '/home/njh/.cpan/build/File-ShareDir-1.116-2/t/lib/auto/ShareDir/TestClass': No such directory at t/06_old.t line 31.
            # Tests were run but no plan was declared and done_testing() was not seen.


Many Thanks.
Best Regards,
Mohammad S Anwar

