### PR TITLE
Fix running tests in parallel

### DIFF
--- a/testrules.yml
+++ b/testrules.yml
@@ -1,0 +1,5 @@
+seq:
+    - seq:
+        - t/04_fail.t
+        - t/06_old.t
+    - par: **


### PR DESCRIPTION
I often install CPAN modules with `HARNESS_OPTIONS=j8 cpan MODULE` so that tests can run more quickly.  Currently, this fails for File::ShareDir sometimes as t/04_fail.t and t/06_old.t use the same directory structures.  This configuration prevents them from doing so.