### PR TITLE
use eval+require rather than use_ok to test for CPAN::Meta to fix plan

### DIFF
--- a/t/00_prereqs.t
+++ b/t/00_prereqs.t
@@ -7,10 +7,10 @@ use Test::More;
 
 # Prereqs-testing for File::ShareDir
 
-TODO:
-{
-    local $TODO = "Just diagnostics ...";
-    use_ok("CPAN::Meta") or plan skip_all => "Need CPAN::Meta for this test";
+BEGIN {
+    if (!eval { require CPAN::Meta; 1 }) {
+        plan skip_all => "Need CPAN::Meta for this test";
+    }
 }
 
 my $meta = CPAN::Meta->load_file(-d "xt" ? "MYMETA.json" : "META.json");


### PR DESCRIPTION
A skip_all plan is incompatible with having any tests.  If CPAN::Meta
was not available, the use_ok would omit a failed TODO test, but then an
incompatible skip_all plan.

Rather than using use_ok, just use a require in an eval block to check
for CPAN::Meta.