### PR TITLE
check version with VERSION method, not import

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,7 +16,8 @@ BEGIN
 }
 
 use inc::latest 'File::ShareDir::Install';
-File::ShareDir::Install->import('0.03', 'install_share');
+File::ShareDir::Install->VERSION(0.03);
+File::ShareDir::Install->import('install_share');
 
 if (inc::latest->can("write"))
 {


### PR DESCRIPTION
Trying to use import to check a version would sometimes check the version, but only if Exporter was being used. Otherwise, the version would throw an error or just be ignored. The correct way to check a version is using the VERSION method.